### PR TITLE
add djangorestframework/coverage to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 sh dockerUpBackend.sh
 
 ## coverage lib commands
-######all commands run in django container  
+#####all commands run in django container  
 run after any code addition: ```coverage run --source='.' manage.py test```  
 then run ```compare report``` or ```compare html``` to get report 
 - The former will simply show report in the terminal

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 sh dockerUpBackend.sh
 
 ## coverage lib commands
-#####all commands run in django container  
+##### all commands run in django container  
 run after any code addition: ```coverage run --source='.' manage.py test```  
 then run ```compare report``` or ```compare html``` to get report 
 - The former will simply show report in the terminal

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@
 
 ## Build backend Docker containers
 sh dockerUpBackend.sh
+
+## coverage lib commands
+######all commands run in django container  
+run after any code addition: ```coverage run --source='.' manage.py test```  
+then run ```compare report``` or ```compare html``` to get report 
+- The former will simply show report in the terminal
+- The latter will make a 'htmlcov' dir (gitignored) with an 'index.html' you can view and look at the report in the browser

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 sh dockerUpBackend.sh
 
 ## coverage lib commands
-##### all commands run in django container  
+##### -all commands run in django container-  
 run after any code addition: ```coverage run --source='.' manage.py test```  
 then run ```compare report``` or ```compare html``` to get report 
 - The former will simply show report in the terminal

--- a/swarmdjango/requirements.txt
+++ b/swarmdjango/requirements.txt
@@ -1,2 +1,4 @@
 Django>=2.0,<3.0
+djangorestframework>=3.0,<4.0
+coverage>=5.0,<6.0
 psycopg2-binary>=2.8


### PR DESCRIPTION
Small PR.

To install new libraries, cli into django container and run
```pip install -r requirements.txt```
 <br/>
Coverage is pretty cool, anytime you add code run ```coverage run --source='.' manage.py test``` 
Then you can run ```coverage report``` or ```coverage html``` 

- The former will just show in terminal
- The latter will make a 'htmlcov' dir (already gitignored) with an 'index.html' you can view and look at the report in the browser