### PR TITLE
bugFix/prodRequests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ swarmpostgres/env.list
 .idea/
 swarmdjango/static/
 swarmdjango/.elasticbeanstalk
+
+.directory

--- a/swarmdjango/swarm_backend/settings.py
+++ b/swarmdjango/swarm_backend/settings.py
@@ -108,6 +108,8 @@ try:
                 'PORT': config('RDS_PORT', default='5432'),
             }
         }
+    else:
+        raise UndefinedValueError
 except UndefinedValueError:
     DATABASES = {
         'default': {

--- a/swarmdjango/swarm_backend/settings.py
+++ b/swarmdjango/swarm_backend/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 from django.core.exceptions import ImproperlyConfigured
 from decouple import config
+from decouple import UndefinedValueError
 import os
 
 # Quick-start development settings - unsuitable for production
@@ -95,18 +96,19 @@ WSGI_APPLICATION = 'swarm_backend.wsgi.application'
 # connect to postgres container via hostname,
 # this is possible as we are running on a network bridge
 
-if 'RDS_HOSTNAME' in os.environ:
-    DATABASES = {
-        'default': {
-            'ENGINE': config('RDS_ENGINE', default='django.db.backends.postgresql'),
-            'NAME': config('RDS_NAME', default='swarm'),
-            'USER': config('RDS_USER', default='admin'),
-            'PASSWORD': config('RDS_PASSWORD', default='DB_PASSWORD'),
-            'HOST': config('RDS_HOST', default='swarmpostgres'),
-            'PORT': config('RDS_PORT', default='5432'),
+try:
+    if config('PRODUCTION', cast=bool):
+        DATABASES = {
+            'default': {
+                'ENGINE': config('RDS_ENGINE', default='django.db.backends.postgresql'),
+                'NAME': config('RDS_NAME', default='swarm'),
+                'USER': config('RDS_USER', default='admin'),
+                'PASSWORD': config('RDS_PASSWORD', default='DB_PASSWORD'),
+                'HOST': config('RDS_HOST', default='swarmpostgres'),
+                'PORT': config('RDS_PORT', default='5432'),
+            }
         }
-    }
-else:
+except UndefinedValueError:
     DATABASES = {
         'default': {
             'ENGINE': config('SQL_ENGINE', default='django.db.backends.postgresql'),


### PR DESCRIPTION
- the previous ```os.environ``` check checks the OS env variables which are different from what the ```decouple``` library checks, that being our ```.env``` file. Essentially the EB instance was trying to connect our local development postgresql server, instead of the RDS instance.
  
- you'll now need the ```PRODUCTION``` variable set to `True` in ```.env``` when deploying to production. Otherwise the database config will be setup with development values.